### PR TITLE
Add deprecation notice in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 Freewvs Wrapper
 ===============
 
+WARNING: This project is deprecated and should not be used anymore. It is not maintained!
+
 |License|
 
 .. |License| image:: https://img.shields.io/github/license/adfinis-sygroup/freewvs-wrapper.svg?style=flat-square 


### PR DESCRIPTION
This fixes #2. The project hasn't been in production for quite a while now. Better deprecate the project than leaving it unmaintained.